### PR TITLE
ENH: Enable osx-arm64 builds

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,6 @@
 provider:
   win: azure
 conda_forge_output_validation: true
+build_platform:
+  osx_arm64: osx_64
+test_on_native_only: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   skip: true  # [py<35]
 


### PR DESCRIPTION
This adds `osx-arm64` builds for conda distribution.


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [xx] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)


